### PR TITLE
Add redirect for last clippy version

### DIFF
--- a/rust-clippy/v0.0.212/index.html
+++ b/rust-clippy/v0.0.212/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/</title>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/">
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/">


### PR DESCRIPTION
The last Clippy version is v0.0.212 which is what is used in the current
documentation links in the lint output. This makes sure that the redirect
works for v0.0.212, too.