### PR TITLE
Implement seamless redirects through a python script

### DIFF
--- a/generate_redirects.py
+++ b/generate_redirects.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Generates redirects for rust-clippy, based on versions.json.
+The rust-clippy repo must be on the gh-pages branch at ../rust-clippy.
+"""
+
+from pathlib import Path
+import json
+
+TEMPLATE = """
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/{version}</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/{version}/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/{version}/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/{version}/" + window.location.hash)
+</script>
+"""
+
+CLIPPY_REDIRECTS = Path('./rust-clippy')
+CLIPPY_REPO = Path('../rust-clippy')
+
+with (CLIPPY_REPO / 'versions.json').open() as versions:
+    for version in json.load(versions):
+        version_dir = CLIPPY_REDIRECTS / version
+        version_file = version_dir / 'index.html'
+
+        version_dir.mkdir(parents=True, exist_ok=True)
+        with version_file.open('wt') as redirect:
+            redirect.write(TEMPLATE.format(version=version))
+
+        print("Wrote", version_file)

--- a/rust-clippy/0.0.124/index.html
+++ b/rust-clippy/0.0.124/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/0.0.124</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/0.0.124/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/0.0.124/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/0.0.124/" + window.location.hash)
+</script>

--- a/rust-clippy/0.0.125/index.html
+++ b/rust-clippy/0.0.125/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/0.0.125</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/0.0.125/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/0.0.125/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/0.0.125/" + window.location.hash)
+</script>

--- a/rust-clippy/0.0.129/index.html
+++ b/rust-clippy/0.0.129/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/0.0.129</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/0.0.129/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/0.0.129/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/0.0.129/" + window.location.hash)
+</script>

--- a/rust-clippy/0.0.136/index.html
+++ b/rust-clippy/0.0.136/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/0.0.136</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/0.0.136/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/0.0.136/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/0.0.136/" + window.location.hash)
+</script>

--- a/rust-clippy/0.0.90/index.html
+++ b/rust-clippy/0.0.90/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/0.0.90</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/0.0.90/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/0.0.90/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/0.0.90/" + window.location.hash)
+</script>

--- a/rust-clippy/current/index.html
+++ b/rust-clippy/current/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/current</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/current/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/current/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/current/" + window.location.hash)
+</script>

--- a/rust-clippy/list/index.html
+++ b/rust-clippy/list/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/list</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/list/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/list/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/list/" + window.location.hash)
+</script>

--- a/rust-clippy/master/index.html
+++ b/rust-clippy/master/index.html
@@ -1,5 +1,11 @@
+
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to https://rust-lang.github.io/rust-clippy/</title>
-<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/">
-<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/master</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/master/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/master/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/master/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.100/index.html
+++ b/rust-clippy/v0.0.100/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.100</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.100/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.100/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.100/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.101/index.html
+++ b/rust-clippy/v0.0.101/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.101</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.101/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.101/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.101/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.102/index.html
+++ b/rust-clippy/v0.0.102/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.102</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.102/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.102/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.102/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.103/index.html
+++ b/rust-clippy/v0.0.103/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.103</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.103/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.103/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.103/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.104/index.html
+++ b/rust-clippy/v0.0.104/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.104</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.104/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.104/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.104/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.105/index.html
+++ b/rust-clippy/v0.0.105/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.105</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.105/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.105/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.105/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.106/index.html
+++ b/rust-clippy/v0.0.106/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.106</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.106/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.106/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.106/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.108/index.html
+++ b/rust-clippy/v0.0.108/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.108</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.108/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.108/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.108/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.109/index.html
+++ b/rust-clippy/v0.0.109/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.109</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.109/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.109/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.109/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.114/index.html
+++ b/rust-clippy/v0.0.114/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.114</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.114/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.114/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.114/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.116/index.html
+++ b/rust-clippy/v0.0.116/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.116</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.116/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.116/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.116/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.118/index.html
+++ b/rust-clippy/v0.0.118/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.118</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.118/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.118/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.118/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.121/index.html
+++ b/rust-clippy/v0.0.121/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.121</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.121/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.121/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.121/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.130/index.html
+++ b/rust-clippy/v0.0.130/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.130</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.130/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.130/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.130/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.131/index.html
+++ b/rust-clippy/v0.0.131/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.131</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.131/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.131/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.131/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.137/index.html
+++ b/rust-clippy/v0.0.137/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.137</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.137/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.137/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.137/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.138/index.html
+++ b/rust-clippy/v0.0.138/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.138</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.138/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.138/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.138/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.140/index.html
+++ b/rust-clippy/v0.0.140/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.140</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.140/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.140/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.140/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.142/index.html
+++ b/rust-clippy/v0.0.142/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.142</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.142/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.142/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.142/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.145/index.html
+++ b/rust-clippy/v0.0.145/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.145</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.145/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.145/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.145/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.147/index.html
+++ b/rust-clippy/v0.0.147/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.147</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.147/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.147/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.147/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.149/index.html
+++ b/rust-clippy/v0.0.149/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.149</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.149/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.149/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.149/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.150/index.html
+++ b/rust-clippy/v0.0.150/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.150</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.150/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.150/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.150/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.151/index.html
+++ b/rust-clippy/v0.0.151/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.151</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.151/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.151/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.151/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.154/index.html
+++ b/rust-clippy/v0.0.154/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.154</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.154/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.154/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.154/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.155/index.html
+++ b/rust-clippy/v0.0.155/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.155</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.155/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.155/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.155/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.156/index.html
+++ b/rust-clippy/v0.0.156/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.156</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.156/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.156/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.156/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.157/index.html
+++ b/rust-clippy/v0.0.157/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.157</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.157/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.157/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.157/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.158/index.html
+++ b/rust-clippy/v0.0.158/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.158</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.158/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.158/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.158/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.159/index.html
+++ b/rust-clippy/v0.0.159/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.159</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.159/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.159/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.159/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.160/index.html
+++ b/rust-clippy/v0.0.160/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.160</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.160/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.160/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.160/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.161/index.html
+++ b/rust-clippy/v0.0.161/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.161</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.161/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.161/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.161/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.162/index.html
+++ b/rust-clippy/v0.0.162/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.162</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.162/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.162/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.162/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.163/index.html
+++ b/rust-clippy/v0.0.163/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.163</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.163/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.163/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.163/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.164/index.html
+++ b/rust-clippy/v0.0.164/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.164</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.164/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.164/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.164/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.165/index.html
+++ b/rust-clippy/v0.0.165/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.165</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.165/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.165/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.165/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.166/index.html
+++ b/rust-clippy/v0.0.166/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.166</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.166/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.166/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.166/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.168/index.html
+++ b/rust-clippy/v0.0.168/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.168</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.168/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.168/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.168/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.171/index.html
+++ b/rust-clippy/v0.0.171/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.171</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.171/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.171/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.171/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.172/index.html
+++ b/rust-clippy/v0.0.172/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.172</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.172/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.172/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.172/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.173/index.html
+++ b/rust-clippy/v0.0.173/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.173</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.173/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.173/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.173/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.174/index.html
+++ b/rust-clippy/v0.0.174/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.174</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.174/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.174/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.174/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.175/index.html
+++ b/rust-clippy/v0.0.175/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.175</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.175/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.175/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.175/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.176/index.html
+++ b/rust-clippy/v0.0.176/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.176</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.176/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.176/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.176/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.177/index.html
+++ b/rust-clippy/v0.0.177/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.177</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.177/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.177/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.177/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.178/index.html
+++ b/rust-clippy/v0.0.178/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.178</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.178/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.178/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.178/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.179/index.html
+++ b/rust-clippy/v0.0.179/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.179</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.179/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.179/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.179/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.180/index.html
+++ b/rust-clippy/v0.0.180/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.180</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.180/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.180/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.180/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.181/index.html
+++ b/rust-clippy/v0.0.181/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.181</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.181/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.181/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.181/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.184/index.html
+++ b/rust-clippy/v0.0.184/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.184</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.184/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.184/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.184/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.185/index.html
+++ b/rust-clippy/v0.0.185/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.185</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.185/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.185/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.185/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.186/index.html
+++ b/rust-clippy/v0.0.186/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.186</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.186/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.186/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.186/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.187/index.html
+++ b/rust-clippy/v0.0.187/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.187</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.187/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.187/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.187/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.188/index.html
+++ b/rust-clippy/v0.0.188/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.188</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.188/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.188/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.188/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.189/index.html
+++ b/rust-clippy/v0.0.189/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.189</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.189/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.189/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.189/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.190/index.html
+++ b/rust-clippy/v0.0.190/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.190</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.190/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.190/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.190/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.191/index.html
+++ b/rust-clippy/v0.0.191/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.191</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.191/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.191/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.191/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.192/index.html
+++ b/rust-clippy/v0.0.192/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.192</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.192/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.192/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.192/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.193/index.html
+++ b/rust-clippy/v0.0.193/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.193</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.193/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.193/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.193/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.194/index.html
+++ b/rust-clippy/v0.0.194/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.194</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.194/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.194/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.194/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.196/index.html
+++ b/rust-clippy/v0.0.196/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.196</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.196/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.196/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.196/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.197/index.html
+++ b/rust-clippy/v0.0.197/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.197</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.197/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.197/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.197/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.198/index.html
+++ b/rust-clippy/v0.0.198/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.198</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.198/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.198/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.198/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.199/index.html
+++ b/rust-clippy/v0.0.199/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.199</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.199/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.199/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.199/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.200/index.html
+++ b/rust-clippy/v0.0.200/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.200</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.200/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.200/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.200/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.201/index.html
+++ b/rust-clippy/v0.0.201/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.201</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.201/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.201/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.201/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.202/index.html
+++ b/rust-clippy/v0.0.202/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.202</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.202/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.202/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.202/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.203/index.html
+++ b/rust-clippy/v0.0.203/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.203</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.203/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.203/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.203/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.204/index.html
+++ b/rust-clippy/v0.0.204/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.204</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.204/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.204/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.204/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.205/index.html
+++ b/rust-clippy/v0.0.205/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.205</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.205/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.205/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.205/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.207/index.html
+++ b/rust-clippy/v0.0.207/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.207</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.207/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.207/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.207/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.208/index.html
+++ b/rust-clippy/v0.0.208/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.208</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.208/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.208/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.208/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.209/index.html
+++ b/rust-clippy/v0.0.209/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.209</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.209/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.209/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.209/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.210/index.html
+++ b/rust-clippy/v0.0.210/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.210</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.210/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.210/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.210/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.211/index.html
+++ b/rust-clippy/v0.0.211/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.211</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.211/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.211/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.211/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.212/index.html
+++ b/rust-clippy/v0.0.212/index.html
@@ -1,5 +1,11 @@
+
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to https://rust-lang.github.io/rust-clippy/</title>
-<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/">
-<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.212</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.212/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.212/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.212/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.83/index.html
+++ b/rust-clippy/v0.0.83/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.83</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.83/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.83/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.83/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.84/index.html
+++ b/rust-clippy/v0.0.84/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.84</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.84/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.84/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.84/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.85/index.html
+++ b/rust-clippy/v0.0.85/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.85</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.85/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.85/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.85/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.86/index.html
+++ b/rust-clippy/v0.0.86/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.86</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.86/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.86/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.86/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.87/index.html
+++ b/rust-clippy/v0.0.87/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.87</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.87/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.87/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.87/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.88/index.html
+++ b/rust-clippy/v0.0.88/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.88</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.88/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.88/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.88/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.89/index.html
+++ b/rust-clippy/v0.0.89/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.89</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.89/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.89/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.89/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.90/index.html
+++ b/rust-clippy/v0.0.90/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.90</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.90/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.90/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.90/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.91/index.html
+++ b/rust-clippy/v0.0.91/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.91</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.91/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.91/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.91/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.92/index.html
+++ b/rust-clippy/v0.0.92/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.92</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.92/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.92/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.92/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.93/index.html
+++ b/rust-clippy/v0.0.93/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.93</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.93/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.93/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.93/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.94/index.html
+++ b/rust-clippy/v0.0.94/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.94</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.94/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.94/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.94/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.95/index.html
+++ b/rust-clippy/v0.0.95/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.95</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.95/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.95/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.95/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.96/index.html
+++ b/rust-clippy/v0.0.96/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.96</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.96/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.96/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.96/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.97/index.html
+++ b/rust-clippy/v0.0.97/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.97</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.97/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.97/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.97/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.98/index.html
+++ b/rust-clippy/v0.0.98/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.98</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.98/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.98/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.98/" + window.location.hash)
+</script>

--- a/rust-clippy/v0.0.99/index.html
+++ b/rust-clippy/v0.0.99/index.html
@@ -1,0 +1,11 @@
+
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-lang.github.io/rust-clippy/v0.0.99</title>
+<link rel="canonical" href="https://rust-lang.github.io/rust-clippy/v0.0.99/">
+<noscript>
+<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rust-clippy/v0.0.99/">
+</noscript>
+<script>
+window.location.replace("https://rust-lang.github.io/rust-clippy/v0.0.99/" + window.location.hash)
+</script>


### PR DESCRIPTION
This script parses the versions.json from the rust-clippy repo,
generating automatic seamless redirects that use javascript to preserve
the lint anchor.

In browsers with javascript disabled, a <meta> tag will be used instead,
preserving version information but losing the lint anchor.

Closes #1