### PR TITLE
[Do not merge yet] Rename `rustc-guide` to `rustc-dev-guide`

### DIFF
--- a/rustc-guide/index.html
+++ b/rustc-guide/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to https://rust-lang.github.io/rustc-guide/</title>
-<meta http-equiv="refresh" content="0; URL=https://rust-lang.github.io/rustc-guide/">
-<link rel="canonical" href="https://rust-lang.github.io/rustc-guide/">
+<title>Redirecting to https://rustc-dev-guide.rust-lang.org/</title>
+<meta http-equiv="refresh" content="0; URL=https://rustc-dev-guide.rust-lang.org/">
+<link rel="canonical" href="https://rustc-dev-guide.rust-lang.org/">


### PR DESCRIPTION
See rust-lang/rustc-guide#602.